### PR TITLE
Some CSS enhancements and other minor additions

### DIFF
--- a/rsvpmaker-for-toastmasters.php
+++ b/rsvpmaker-for-toastmasters.php
@@ -1077,7 +1077,14 @@ foreach ($wp4toastmasters_officer_ids as $index => $officer_id)
 			continue;
 		$officer = get_userdata($officer_id);
 		$title = str_replace(' ','&nbsp;',$wp4toastmasters_officer_titles[$index]);
-		$buffer .= sprintf('<div class="officer_entity"><p>%s<officertitle>%s</officertitle><br><officer>%s&nbsp;%s</officer>&nbsp;<educationawards>%s</educationawards></p></div>',$sep,$title,$officer->first_name,$officer->last_name, $officer->education_awards);
+		if ($enhanced_css == 1)
+		    {
+		        $buffer .= sprintf('<div class="officer_entity"><p>%s<officertitle>%s</officertitle><br><officer>%s&nbsp;%s</officer>&nbsp;<educationawards>%s</educationawards></p></div>',$sep,$title,$officer->first_name,$officer->last_name, $officer->education_awards);
+		    }
+		else
+		    {
+		        $buffer .= sprintf('%s<em>%s</em>&nbsp;%s&nbsp;%s',$sep,$title,$officer->first_name,$officer->last_name);
+		    }
 	}
 }
 else


### PR DESCRIPTION
**"Enhances" css for some flexibility I needed for my club's agenda.**
With these extra tags, and some strategic `<li>'s,` I am at this point with our club's new agenda design:

![image](https://user-images.githubusercontent.com/26885890/27066458-5d75d268-4fd2-11e7-95dd-333fe648e7a1.png)

Lines in question: 778 - 1676

Notice I also added an Evaluator "evaluates Speaker" (lines 821-832) and added Speaker "#" after speaker (812 - 818).. 

This is all toggled (line 2752) on the settings page for "wp4toastmasters_agenda_enhanced_css" that writes 1 (on) or 0 (off) to the options table.

![image](https://user-images.githubusercontent.com/26885890/27066505-ae9d72f4-4fd2-11e7-9f2b-f720812a9ae7.png)

Admitedly, This a bit spaghetti code-ish. Hopefully some day my object oriented skills will be beefy enough to take on refactoring some of this...


**Time Redundancy in Ice Breaker Speeches**
I also noticed that there was a redundancy in the times shown for the "The Ice Breaker" speech (I noticed it said "(4 to 6 min) (4 - 6 minutes)" on the agenda print out and in the drop down menu). This didn't seem right to me, and by eliminating where it was redundant, it rendered correctly without showing twice. To be honest, the manual definitions in the code are still a bit black boxish for me, so I might have done something bad here. Numerous blocks in lines 6945-7895


**Tag Line Shortcode**
Added a tmlayout_tag_line shortcode on 10407 so I could use this in the agenda:
![image](https://user-images.githubusercontent.com/26885890/27066598-3eb9b8b6-4fd3-11e7-9464-65d6ef7b1cf0.png)
